### PR TITLE
Avoid creating new regl commands when specifying framebuffer

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -69,6 +69,7 @@ async function main() {
   await display();
   const samples = 512;
   let t0 = performance.now();
+  let tStart = t0;
   for (let i = 0; i < samples; i++) {
     aoSampler.sample();
     if (performance.now() - t0 > 100) {
@@ -77,6 +78,8 @@ async function main() {
       t0 = performance.now();
     }
   }
+  var tEnd = performance.now();
+  console.info('Computed '+samples+' samples in '+(tEnd - tStart).toFixed(1)+'ms');
 
   // We're done with the progress bar, hide it.
   fraction(0);

--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ module.exports = function(positions, opts) {
     mat4.rotateX(model, model, Math.random() * 100);
     mat4.rotateY(model, model, Math.random() * 100);
     mat4.rotateZ(model, model, Math.random() * 100);
-    regl({framebuffer: fboPosition})(() => {
+    fboPosition.use(() => {
       regl.clear({
         color: [0,0,0,1],
         depth: 1,
@@ -214,7 +214,7 @@ module.exports = function(positions, opts) {
       model: model,
       projection: projection,
     });
-    regl({framebuffer: destination})(() => {
+    destination.use(() => {
       regl.clear({
         color: [0,0,0,1],
         depth: 1,
@@ -234,7 +234,7 @@ module.exports = function(positions, opts) {
   function report() {
     // Gather the resulting pixels.
     let pixels;
-    regl({framebuffer: fboOcclusion[1 - occlusionIndex]})(() => {
+    fboOcclusion[1 - occlusionIndex].use(() => {
       pixels = regl.read();
     });
 


### PR DESCRIPTION
The code currently uses the syntax `regl({framebuffer: ...})(() => { ... })` to set the destination framebuffer. That causes quite a bit of regl command setup on each sample.

This PR changes to the syntax to `dstFbo.use(() => { ... })` and turns out to reduce the time from about 4380ms on my computer down to 135ms for the stanford dragon example, about ~32x faster!