### PR TITLE
Allow precomputed normals

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ aoSampler.dispose();
 * `resolution` (int) is the resolution to build the depth buffer at. Defaults to `512`.
 * `bias` (float) is the bias applied to the shadow map while building the ambient occlusion data. Defaults to `0.01`.
 * `cells` is the index data for your mesh, if you're using a [simplicial complex](https://github.com/mikolalysenko/simplicial-complex). Defaults to `undefined`.
+* `normals` are per-vertex normals, either in an array or array of arrays. If not supplied, they will be computed using the [normals](https://www.npmjs.com/package/normals) npm module.
 * `regl` is an optional [regl](https://github.com/regl-project/regl) context you can provide to reduced the overhead of
 multiple WebGL contexts. This context will need to have the `OES_texture_float` extension enabled, and depending on the
 size of your mesh, also the `OES_element_index_uint` extension.

--- a/index.js
+++ b/index.js
@@ -45,7 +45,12 @@ module.exports = function(positions, opts) {
   if (mesh.cells === undefined) {
     mesh = reindex(vertexData);
   }
-  const normals = vertexNormals(mesh.cells, mesh.positions, 0);
+  let normals;
+  if (opts.normals === undefined) {
+    normals = vertexNormals(mesh.cells, mesh.positions, 0);
+  } else {
+    normals = opts.normals;
+  }
   const normalData = converter.convert(normals, converter.TYPED_ARRAY);
 
   // Make sure the position array is divisible by three.


### PR DESCRIPTION
This module is so great! The only thing that prevented me from using it out of the box is that my cells were in a flat typed array rather than an array of arrays. The solution was simply to just use the flat array but to compute the normals myself, rather than using the normals module (which requires an array of arrays).

<img width="488" alt="screen shot 2019-01-30 at 8 36 55 pm" src="https://user-images.githubusercontent.com/572717/52030954-e972f980-24ce-11e9-9c93-ee52bba91935.png">
